### PR TITLE
fix: jazzy doc generate fail

### DIFF
--- a/.github/workflows/jazzy_build.yml
+++ b/.github/workflows/jazzy_build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
 jobs:
-  deploy:
+  jazzy-build:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jazzy_build.yml
+++ b/.github/workflows/jazzy_build.yml
@@ -1,0 +1,12 @@
+name: Jazzy build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  deploy:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate docs
+        run: jazzy

--- a/.github/workflows/jazzy_doc_gen.yml
+++ b/.github/workflows/jazzy_doc_gen.yml
@@ -20,3 +20,5 @@ jobs:
           git add docs
           git commit -m "chore: update API docs"
           git push origin HEAD:gh-pages -f
+        env:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -12,4 +12,5 @@ theme: apple
 build_tool_arguments:
   - -Xswiftc
   - -swift-version
+  - -Xswiftc
   - "5"


### PR DESCRIPTION
## Issue 
<!-- If applicable, please link to issue(s) this change addresses -->
closes #8 

## Description
<!-- Why is this change required? What problem does it solve? -->
fix the jazzy_doc_gen action fail. 
test [jazzy doc gen action](https://github.com/awslabs/clickstream-swift/actions/runs/5075163163) passed.
test [pages build and publish action](https://github.com/awslabs/clickstream-swift/actions/runs/5075187982) passed.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
