### PR TITLE
fix: disable record screenview event if it's no enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Your `appId` and `endpoint` are already set up in it, here's an explanation of e
 
 **3.Initialize the SDK**
 
-Once you have configured the parameters, you need to initialize it in AppDelegate's `didFinishLaunchingWithOptions` lifecycle method to use the SDK.
+Once you have configured the parameters, you need to initialize it in your app delegate's `application(_:didFinishLaunchingWithOptions:)` lifecycle method:
 
 ```swift
 import Clickstream
@@ -78,7 +78,23 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 }
 ```
 
-**4.Config the SDK**
+If your project is developed with SwiftUI, you need to create an application delegate and attach it to your `App` through `UIApplicationDelegateAdaptor`. 
+
+```swift
+@main
+struct YourApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    var body: some Scene {
+        WindowGroup {
+            YourView()
+        }
+    }
+}
+```
+
+You also need to disable swzzling by setting `configuration.isTrackScreenViewEvents = false`, see the next configuration steps.
+
+**4.Configure the SDK**
 
 ```swift
 import Clickstream
@@ -90,7 +106,7 @@ do {
     configuration.endpoint = "https://example.com/collect"
     configuration.authCookie = "your authentication cookie"
     configuration.sessionTimeoutDuration = 1800000
-    configuration.isTrackAppExceptionEvents = false
+    configuration.isTrackScreenViewEvents = true
     configuration.isLogEvents = true
     configuration.isCompressEvents = true    
     configuration.isLogEvents = true

--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -92,6 +92,9 @@ class AutoRecordEventClient {
     }
 
     func onViewDidAppear(screenName: String, screenPath: String) {
+        if !clickstream.configuration.isTrackScreenViewEvents {
+            return
+        }
         let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SCREEN_VIEW)
         event.addAttribute(screenName, forKey: Event.ReservedAttribute.SCREEN_NAME)
         event.addAttribute(screenPath, forKey: Event.ReservedAttribute.SCREEN_ID)

--- a/Sources/Clickstream/Dependency/Clickstream/ClickstreamContext.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/ClickstreamContext.swift
@@ -58,7 +58,7 @@ extension UserDefaults: UserDefaultsBehaviour {
          endpoint: String,
          sendEventsInterval: Int,
          isTrackAppExceptionEvents: Bool = true,
-         isTrackAppLifecycleEvents: Bool = true,
+         isTrackScreenViewEvents: Bool = true,
          isCompressEvents: Bool = true,
          isLogEvents: Bool = false,
          sessionTimeoutDuration: Int64 = 1_800_000)
@@ -67,7 +67,7 @@ extension UserDefaults: UserDefaultsBehaviour {
         self.endpoint = endpoint
         self.sendEventsInterval = sendEventsInterval
         self.isTrackAppExceptionEvents = isTrackAppExceptionEvents
-        self.isTrackScreenViewEvents = isTrackAppLifecycleEvents
+        self.isTrackScreenViewEvents = isTrackScreenViewEvents
         self.isCompressEvents = isCompressEvents
         self.isLogEvents = isLogEvents
         self.sessionTimeoutDuration = sessionTimeoutDuration

--- a/Tests/ClickstreamTests/Clickstream/AutoRecordEventClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AutoRecordEventClientTest.swift
@@ -115,4 +115,16 @@ class AutoRecordEventClientTest: XCTestCase {
 
         XCTAssertTrue(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENTRANCES] as! Int == 0)
     }
+
+    func testCloseRecordScreenView() {
+        clickstream.configuration.isTrackScreenViewEvents = false
+        autoRecordEventClient.updateEngageTimestamp()
+        autoRecordEventClient.setIsEntrances()
+        let viewController = MockViewControllerA()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        XCTAssertTrue(viewController.viewDidAppearCalled)
+        XCTAssertTrue(eventRecorder.saveCount == 0)
+    }
 }


### PR DESCRIPTION
## Issue
Fixed Gitlab issue [#423](https://gitlab.aws.dev/aws-gcr-solutions/incubator/web-analytics-on-aws/clickstream-analytics-on-aws/-/issues/423)

## Description
<!-- Why is this change required? What problem does it solve? -->
1. Fix the configuration for disable record screen view event is not work.
2. Add integrate step for SwiftUI project in readme.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
