### PR TITLE
fix: timestamp order in event and user attributes.

### DIFF
--- a/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
+++ b/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
@@ -10,25 +10,23 @@ import Foundation
 
 extension AWSClickstreamPlugin {
     func identifyUser(userId: String, userProfile: AnalyticsUserProfile?) {
-        if userId == Event.User.USER_ID_EMPTY {
-            userProfile?.properties?.forEach { key, value in
-                Task {
-                    await analyticsClient.addUserAttribute(value, forKey: key)
+        Task {
+            if userId == Event.User.USER_ID_EMPTY {
+                if let attributes = userProfile?.properties {
+                    for attribute in attributes {
+                        await analyticsClient.addUserAttribute(attribute.value, forKey: attribute.key)
+                    }
                 }
-            }
-        } else {
-            Task {
+            } else {
                 if userId == Event.User.USER_ID_NIL {
                     await analyticsClient.updateUserId(nil)
                 } else {
                     await analyticsClient.updateUserId(userId)
                 }
             }
-        }
-        Task {
             await analyticsClient.updateUserAttributes()
+            record(eventWithName: Event.PresetEvent.PROFILE_SET)
         }
-        record(eventWithName: Event.PresetEvent.PROFILE_SET)
     }
 
     func record(event: AnalyticsEvent) {

--- a/Sources/Clickstream/ClickstreamAnalytics.swift
+++ b/Sources/Clickstream/ClickstreamAnalytics.swift
@@ -17,7 +17,7 @@ public enum ClickstreamAnalytics {
 
     /// Use this method to record event
     /// - Parameter eventName: the event name
-    public static func recordEvent(eventName: String) {
+    public static func recordEvent(_ eventName: String) {
         Amplify.Analytics.record(eventWithName: eventName)
     }
 
@@ -25,7 +25,7 @@ public enum ClickstreamAnalytics {
     /// - Parameters:
     ///   - eventName: the event name
     ///   - attributes: the event attributes
-    public static func recordEvent(eventName: String, attributes: ClickstreamAttribute) {
+    public static func recordEvent(_ eventName: String, _ attributes: ClickstreamAttribute) {
         let event = BaseClickstreamEvent(name: eventName, attribute: attributes)
         Amplify.Analytics.record(event: event)
     }
@@ -37,19 +37,19 @@ public enum ClickstreamAnalytics {
 
     /// Add global attributes
     /// - Parameter attributes: the global attributes to add
-    public static func addGlobalAttributes(attributes: ClickstreamAttribute) {
+    public static func addGlobalAttributes(_ attributes: ClickstreamAttribute) {
         Amplify.Analytics.registerGlobalProperties(attributes)
     }
 
     /// Delete global attributes
     /// - Parameter attributes: the global attributes names to delete
-    public static func deleteGlobalAttributes(attributes: String...) {
+    public static func deleteGlobalAttributes(_ attributes: String...) {
         Amplify.Analytics.unregisterGlobalProperties(attributes)
     }
 
     /// Add user attributes
     /// - Parameter attributes: the user attributes to add
-    public static func addUserAttributes(attributes: ClickstreamAttribute) {
+    public static func addUserAttributes(_ attributes: ClickstreamAttribute) {
         let userProfile = AnalyticsUserProfile(location: nil, properties: attributes)
         Amplify.Analytics.identifyUser(userId: Event.User.USER_ID_EMPTY,
                                        userProfile: userProfile)
@@ -57,7 +57,7 @@ public enum ClickstreamAnalytics {
 
     /// Set user id for login and logout
     /// - Parameter userId: current userId, nil for logout
-    public static func setUserId(userId: String?) {
+    public static func setUserId(_ userId: String?) {
         if userId == nil {
             Amplify.Analytics.identifyUser(userId: Event.User.USER_ID_NIL)
         } else {

--- a/Sources/Clickstream/ClickstreamObjc.swift
+++ b/Sources/Clickstream/ClickstreamObjc.swift
@@ -9,6 +9,13 @@ import Foundation
 
 /// ClickstreamAnalytics api for objective-c
 @objcMembers public class ClickstreamObjc: NSObject {
+    
+    /// Hide the constructor
+    @nonobjc
+    override private init() {
+        super.init()
+    }
+
     /// Init the Clickstream sdk
     public static func initSDK() throws {
         try ClickstreamAnalytics.initSDK()
@@ -17,7 +24,7 @@ import Foundation
     /// Use this method to record event
     /// - Parameter eventName: the event name
     public static func recordEvent(_ eventName: String) {
-        ClickstreamAnalytics.recordEvent(eventName: eventName)
+        ClickstreamAnalytics.recordEvent(eventName)
     }
 
     /// The method to record event with attributes
@@ -25,7 +32,7 @@ import Foundation
     ///   - eventName: the event name
     ///   - attributes: the event attributes which type is NSDictionary
     public static func recordEvent(_ eventName: String, _ attributes: NSDictionary) {
-        ClickstreamAnalytics.recordEvent(eventName: eventName, attributes: getAttributes(attributes))
+        ClickstreamAnalytics.recordEvent(eventName, getAttributes(attributes))
     }
 
     /// Use this method to send events immediately
@@ -36,27 +43,27 @@ import Foundation
     /// Add global attributes
     /// - Parameter attributes: the global attributes to add
     public static func addGlobalAttributes(_ attributes: NSDictionary) {
-        ClickstreamAnalytics.addGlobalAttributes(attributes: getAttributes(attributes))
+        ClickstreamAnalytics.addGlobalAttributes(getAttributes(attributes))
     }
 
     /// Delete global attributes
     /// - Parameter attributes: the global attributes names to delete
     public static func deleteGlobalAttributes(_ attributes: [String]) {
         for attribute in attributes {
-            ClickstreamAnalytics.deleteGlobalAttributes(attributes: attribute)
+            ClickstreamAnalytics.deleteGlobalAttributes(attribute)
         }
     }
 
     /// Add user attributes
     /// - Parameter attributes: the user attributes to add
     public static func addUserAttributes(_ attributes: NSDictionary) {
-        ClickstreamAnalytics.addUserAttributes(attributes: getAttributes(attributes))
+        ClickstreamAnalytics.addUserAttributes(getAttributes(attributes))
     }
 
     /// Set user id for login and logout
     /// - Parameter userId: current userId, nil for logout
     public static func setUserId(_ userId: String?) {
-        ClickstreamAnalytics.setUserId(userId: userId)
+        ClickstreamAnalytics.setUserId(userId)
     }
 
     /// Get Clickstream configuration, please config it after initialize sdk

--- a/Sources/Clickstream/PackageInfo.swift
+++ b/Sources/Clickstream/PackageInfo.swift
@@ -8,5 +8,5 @@
 enum PackageInfo {
     /// the clickstream analytics iOS sdk version
     /// note: update and align the version with new tag version before committing new tag
-    static let version = "0.4.2"
+    static let version = "0.5.0"
 }


### PR DESCRIPTION
## Issue 
<!-- If applicable, please link to issue(s) this change addresses -->

The timestamp of set_timestamp_micros in the user_properties is later than the event_timestamp

## Description
<!-- Why is this change required? What problem does it solve? -->
1. Fixed the time order in event and user attributes.
2. Simplify the SDK api.


## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
