### PR TITLE
feat: add _app_start event, change user engagement attribute

### DIFF
--- a/Sources/Clickstream/Dependency/Clickstream/Event/Event.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/Event.swift
@@ -166,6 +166,7 @@ enum Event {
         static let PREVIOUS_SCREEN_NAME = "_previous_screen_name"
         static let SCREEN_ID = "_screen_id"
         static let SCREEN_NAME = "_screen_name"
+        static let IS_FIRST_TIME = "_is_first_time"
     }
 
     enum User {
@@ -207,6 +208,7 @@ enum Event {
         static let FIRST_OPEN = "_first_open"
         static let USER_ENGAGEMENT = "_user_engagement"
         static let SCREEN_VIEW = "_screen_view"
+        static let APP_START = "_app_start"
     }
 
     enum ErrorType {

--- a/Sources/Clickstream/Dependency/Clickstream/Session/SessionClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Session/SessionClient.swift
@@ -58,7 +58,7 @@ class SessionClient: SessionClientBehaviour {
     private func handleAppEnterForeground() {
         log.debug("Application entered the foreground.")
         autoRecordClient.updateEngageTimestamp()
-        autoRecordClient.handleFirstOpen()
+        autoRecordClient.handleAppStart()
         let isNewSession = initialSession()
         if isNewSession {
             autoRecordClient.setIsEntrances()

--- a/Tests/ClickstreamTests/Clickstream/AutoRecordEventClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AutoRecordEventClientTest.swift
@@ -81,7 +81,7 @@ class AutoRecordEventClientTest: XCTestCase {
         XCTAssertTrue(eventRecorder.lastSavedEvent?.eventType == Event.PresetEvent.SCREEN_VIEW)
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.SCREEN_ID])
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.SCREEN_NAME])
-        XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP])
+        XCTAssertNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP])
         XCTAssertNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.PREVIOUS_SCREEN_ID])
         XCTAssertNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.PREVIOUS_SCREEN_NAME])
         XCTAssertTrue(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENTRANCES] as! Int == 1)
@@ -104,6 +104,9 @@ class AutoRecordEventClientTest: XCTestCase {
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.SCREEN_ID])
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.SCREEN_NAME])
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP])
+        XCTAssertTrue(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP]
+                      as! Int64 >= 0)
+
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.PREVIOUS_SCREEN_ID])
         XCTAssertNotNil(eventRecorder.lastSavedEvent!.attributes[Event.ReservedAttribute.PREVIOUS_SCREEN_NAME])
 

--- a/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
+++ b/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
@@ -106,7 +106,7 @@ class SessionClientTests: XCTestCase {
         XCTAssertTrue(session.pauseTime != nil)
         let storedSession = UserDefaultsUtil.getSession(storage: clickstream.storage)
         XCTAssertTrue(storedSession != nil)
-
+        Thread.sleep(forTimeInterval: 0.1)
         let events = eventRecorder.savedEvents
         XCTAssertEqual(4, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
@@ -156,6 +156,7 @@ class SessionClientTests: XCTestCase {
         window.makeKeyAndVisible()
         activityTracker.callback?(.runningInBackground)
         activityTracker.callback?(.runningInForeground)
+        Thread.sleep(forTimeInterval: 0.1)
         let events = eventRecorder.savedEvents
         XCTAssertEqual(5, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)

--- a/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
+++ b/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
@@ -75,9 +75,10 @@ class SessionClientTests: XCTestCase {
 
         Thread.sleep(forTimeInterval: 0.1)
         let events = eventRecorder.savedEvents
-        XCTAssertEqual(2, events.count)
+        XCTAssertEqual(3, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
-        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[2].eventType)
     }
 
     func testGoBackground() {
@@ -91,9 +92,10 @@ class SessionClientTests: XCTestCase {
         XCTAssertTrue(storedSession != nil)
 
         let events = eventRecorder.savedEvents
-        XCTAssertEqual(2, events.count)
+        XCTAssertEqual(3, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
-        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[2].eventType)
     }
 
     func testGoBackgroundWithUserEngagement() {
@@ -106,10 +108,11 @@ class SessionClientTests: XCTestCase {
         XCTAssertTrue(storedSession != nil)
 
         let events = eventRecorder.savedEvents
-        XCTAssertEqual(3, events.count)
+        XCTAssertEqual(4, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
-        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[1].eventType)
-        XCTAssertEqual(Event.PresetEvent.USER_ENGAGEMENT, events[2].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[2].eventType)
+        XCTAssertEqual(Event.PresetEvent.USER_ENGAGEMENT, events[3].eventType)
     }
 
     func testReturnToForeground() {
@@ -137,9 +140,34 @@ class SessionClientTests: XCTestCase {
 
         Thread.sleep(forTimeInterval: 0.1)
         let events = eventRecorder.savedEvents
-        XCTAssertEqual(3, events.count)
+        XCTAssertEqual(5, events.count)
         XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
-        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[1].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[1].eventType)
         XCTAssertEqual(Event.PresetEvent.SESSION_START, events[2].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[3].eventType)
+        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[4].eventType)
+    }
+
+    func testReturnToForegroundWithScreenView() {
+        activityTracker.callback?(.runningInForeground)
+        let viewController = MockViewControllerA()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        activityTracker.callback?(.runningInBackground)
+        activityTracker.callback?(.runningInForeground)
+        let events = eventRecorder.savedEvents
+        XCTAssertEqual(5, events.count)
+        XCTAssertEqual(Event.PresetEvent.FIRST_OPEN, events[0].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[1].eventType)
+        XCTAssertTrue(events[1].attributes[Event.ReservedAttribute.IS_FIRST_TIME] as! Bool)
+
+        XCTAssertEqual(Event.PresetEvent.SESSION_START, events[2].eventType)
+        XCTAssertEqual(Event.PresetEvent.SCREEN_VIEW, events[3].eventType)
+        XCTAssertEqual(Event.PresetEvent.APP_START, events[4].eventType)
+        let appStartEvent = events[4]
+        XCTAssertNotNil(appStartEvent.attributes[Event.ReservedAttribute.SCREEN_NAME])
+        XCTAssertNotNil(appStartEvent.attributes[Event.ReservedAttribute.SCREEN_ID])
+        XCTAssertFalse(appStartEvent.attributes[Event.ReservedAttribute.IS_FIRST_TIME] as! Bool)
     }
 }

--- a/Tests/ClickstreamTests/IntegrationTest.swift
+++ b/Tests/ClickstreamTests/IntegrationTest.swift
@@ -66,24 +66,23 @@ class IntegrationTest: XCTestCase {
             "Successful": true,
             "Score": 90
         ])
-        ClickstreamAnalytics.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertEqual(0, eventCount)
+        XCTAssertEqual(1, eventCount)
     }
 
     func testRecordOneEventWithNameSuccess() throws {
         ClickstreamAnalytics.recordEvent("testEvent")
-        ClickstreamAnalytics.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertEqual(0, eventCount)
+        XCTAssertEqual(1, eventCount)
     }
 
     func testFlushEvents() throws {
         ClickstreamAnalytics.recordEvent("testEvent")
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.flushEvents()
-        Thread.sleep(forTimeInterval: 0.2)
+        Thread.sleep(forTimeInterval: 0.5)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
         XCTAssertEqual(0, eventCount)
     }
@@ -95,6 +94,7 @@ class IntegrationTest: XCTestCase {
             "class": 5,
             "isOpenNotification": true
         ])
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.recordEvent("testEvent")
         Thread.sleep(forTimeInterval: 0.1)
 
@@ -113,7 +113,9 @@ class IntegrationTest: XCTestCase {
             "class": 5,
             "isOpenNotification": true
         ])
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.deleteGlobalAttributes("channel")
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.recordEvent("testEvent")
         Thread.sleep(forTimeInterval: 0.1)
 
@@ -127,13 +129,14 @@ class IntegrationTest: XCTestCase {
 
     func testAddUserAttribute() throws {
         ClickstreamAnalytics.setUserId("13232")
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.addUserAttributes([
             "_user_age": 21,
             "isFirstOpen": true,
             "score": 85.2,
             "_user_name": "carl"
         ])
-        Thread.sleep(forTimeInterval: 0.1)
+        Thread.sleep(forTimeInterval: 0.2)
         ClickstreamAnalytics.recordEvent("testEvent")
         Thread.sleep(forTimeInterval: 0.1)
         let testEvent = try getTestEvent()
@@ -156,6 +159,7 @@ class IntegrationTest: XCTestCase {
 
     func testSetUserIdNil() throws {
         ClickstreamAnalytics.setUserId("12345")
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamAnalytics.setUserId(nil)
         ClickstreamAnalytics.recordEvent("testEvent")
         Thread.sleep(forTimeInterval: 0.1)
@@ -220,10 +224,9 @@ class IntegrationTest: XCTestCase {
         let configuration = try ClickstreamAnalytics.getClickstreamConfiguration()
         configuration.endpoint = testFailEndpoint
         ClickstreamAnalytics.recordEvent("testEvent")
-        ClickstreamAnalytics.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertNotEqual(0, eventCount)
+        XCTAssertEqual(1, eventCount)
     }
 
     func testModifyConfiguration() throws {
@@ -232,10 +235,9 @@ class IntegrationTest: XCTestCase {
         configuration.isLogEvents = true
         configuration.authCookie = "authCookie"
         ClickstreamAnalytics.recordEvent("testEvent")
-        ClickstreamAnalytics.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertEqual(0, eventCount)
+        XCTAssertEqual(1, eventCount)
     }
 
     // MARK: - Objc test
@@ -249,10 +251,9 @@ class IntegrationTest: XCTestCase {
         ]
         ClickstreamObjc.recordEvent("userId")
         ClickstreamObjc.recordEvent("testEvent", attribute)
-        ClickstreamObjc.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertEqual(0, eventCount)
+        XCTAssertEqual(2, eventCount)
     }
 
     func testGlobalAttributeForObjc() throws {
@@ -263,6 +264,7 @@ class IntegrationTest: XCTestCase {
             "level": 5
         ]
         ClickstreamObjc.addGlobalAttributes(attribute)
+        Thread.sleep(forTimeInterval: 0.1)
         ClickstreamObjc.deleteGlobalAttributes(["Channel"])
         Thread.sleep(forTimeInterval: 0.1)
         ClickstreamObjc.recordEvent("testEvent")
@@ -301,10 +303,9 @@ class IntegrationTest: XCTestCase {
         configuration.isCompressEvents = true
         configuration.authCookie = "authCookie"
         ClickstreamAnalytics.recordEvent("testEvent")
-        ClickstreamAnalytics.flushEvents()
         Thread.sleep(forTimeInterval: 0.2)
         let eventCount = try eventRecorder.dbUtil.getEventCount()
-        XCTAssertEqual(0, eventCount)
+        XCTAssertEqual(1, eventCount)
     }
 
     private func getTestEvent() throws -> [String: Any] {


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
1. add _app_start event
2. change user engagement attribute in screen_view

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
