### PR TITLE
fix: update screen start timestamp when app enter foreground

### DIFF
--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -89,6 +89,10 @@ class AutoRecordEventClient {
         }
     }
 
+    func updateLastScreenStartTimestamp() {
+        lastScreenStartTimestamp = Date().millisecondsSince1970
+    }
+
     func getPreviousScreenViewTimestamp() -> Int64 {
         if lastScreenStartTimestamp > 0 {
             return lastScreenStartTimestamp

--- a/Sources/Clickstream/Dependency/Clickstream/Session/SessionClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Session/SessionClient.swift
@@ -58,6 +58,7 @@ class SessionClient: SessionClientBehaviour {
     private func handleAppEnterForeground() {
         log.debug("Application entered the foreground.")
         autoRecordClient.handleAppStart()
+        autoRecordClient.updateLastScreenStartTimestamp()
         let isNewSession = initialSession()
         if isNewSession {
             autoRecordClient.setIsEntrances()

--- a/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
+++ b/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
@@ -202,6 +202,6 @@ class SessionClientTests: XCTestCase {
         XCTAssertEqual(7, events.count)
         let userEngagementEvent = events[6]
         XCTAssertEqual(Event.PresetEvent.USER_ENGAGEMENT, userEngagementEvent.eventType)
-        XCTAssertTrue((userEngagementEvent.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP] as! Int64) < 1200)
+        XCTAssertTrue((userEngagementEvent.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP] as! Int64) < 1_200)
     }
 }

--- a/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
+++ b/Tests/ClickstreamTests/Clickstream/SessionClientTests.swift
@@ -187,4 +187,21 @@ class SessionClientTests: XCTestCase {
         XCTAssertNotNil(appStartEvent.attributes[Event.ReservedAttribute.SCREEN_ID])
         XCTAssertFalse(appStartEvent.attributes[Event.ReservedAttribute.IS_FIRST_TIME] as! Bool)
     }
+
+    func testLastScreenStartTimeStampUpdatedAfterReturnToForeground() {
+        activityTracker.callback?(.runningInForeground)
+        let viewController = MockViewControllerA()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        Thread.sleep(forTimeInterval: 0.2)
+        activityTracker.callback?(.runningInForeground)
+        Thread.sleep(forTimeInterval: 1)
+        activityTracker.callback?(.runningInBackground)
+        let events = eventRecorder.savedEvents
+        XCTAssertEqual(7, events.count)
+        let userEngagementEvent = events[6]
+        XCTAssertEqual(Event.PresetEvent.USER_ENGAGEMENT, userEngagementEvent.eventType)
+        XCTAssertTrue((userEngagementEvent.attributes[Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP] as! Int64) < 1200)
+    }
 }


### PR DESCRIPTION
## Description
1. update screen start timestamp when app enter foreground.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
