### PR TITLE
feat: add error code and clickstream error event

### DIFF
--- a/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
+++ b/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
@@ -38,16 +38,17 @@ extension AWSClickstreamPlugin {
             log.warn("Cannot record events. Clickstream is disabled")
             return
         }
-        let clickstreamEvent = analyticsClient.createEvent(withEventType: event.name)
-        if let attributes = event.attribute {
-            clickstreamEvent.addAttribute(attributes)
-        }
+        if let clickstreamEvent = analyticsClient.createEvent(withEventType: event.name) {
+            if let attributes = event.attribute {
+                clickstreamEvent.addAttribute(attributes)
+            }
 
-        Task {
-            do {
-                try await analyticsClient.record(clickstreamEvent)
-            } catch {
-                log.error("Record event error:\(error)")
+            Task {
+                do {
+                    try await analyticsClient.record(clickstreamEvent)
+                } catch {
+                    log.error("Record event error:\(error)")
+                }
             }
         }
     }

--- a/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
+++ b/Sources/Clickstream/AWSClickstreamPlugin+ClientBehavior.swift
@@ -38,7 +38,10 @@ extension AWSClickstreamPlugin {
             log.warn("Cannot record events. Clickstream is disabled")
             return
         }
-        if let clickstreamEvent = analyticsClient.createEvent(withEventType: event.name) {
+
+        let isValidEventName = analyticsClient.checkEventName(event.name)
+        if isValidEventName {
+            let clickstreamEvent = analyticsClient.createEvent(withEventType: event.name)
             if let attributes = event.attribute {
                 clickstreamEvent.addAttribute(attributes)
             }

--- a/Sources/Clickstream/Dependency/Clickstream/Analytics/AnalyticsClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Analytics/AnalyticsClient.swift
@@ -15,7 +15,7 @@ protocol AnalyticsClientBehaviour {
     func updateUserId(_ id: String?)
     func updateUserAttributes()
 
-    func createEvent(withEventType eventType: String) -> ClickstreamEvent
+    func createEvent(withEventType eventType: String) -> ClickstreamEvent?
     func record(_ event: ClickstreamEvent) async throws
     func submitEvents(isBackgroundMode: Bool)
 }
@@ -43,8 +43,8 @@ class AnalyticsClient: AnalyticsClientBehaviour {
 
     func addGlobalAttribute(_ attribute: AttributeValue, forKey key: String) {
         let eventError = Event.checkAttribute(currentNumber: globalAttributes.count, key: key, value: attribute)
-        if eventError != nil {
-            globalAttributes[eventError!.errorType] = eventError!.errorMessage
+        if eventError.errorCode > 0 {
+            recordEventError(eventError)
         } else {
             globalAttributes[key] = attribute
         }
@@ -52,8 +52,8 @@ class AnalyticsClient: AnalyticsClientBehaviour {
 
     func addUserAttribute(_ attribute: AttributeValue, forKey key: String) {
         let eventError = Event.checkUserAttribute(currentNumber: userAttributes.count, key: key, value: attribute)
-        if eventError != nil {
-            globalAttributes[eventError!.errorType] = eventError!.errorMessage
+        if eventError.errorCode > 0 {
+            recordEventError(eventError)
         } else {
             var userAttribute = JsonObject()
             if let attributeValue = attribute as? Double {
@@ -101,10 +101,12 @@ class AnalyticsClient: AnalyticsClientBehaviour {
 
     // MARK: - Event recording
 
-    func createEvent(withEventType eventType: String) -> ClickstreamEvent {
-        let (isValid, errorType) = Event.isValidEventType(eventType: eventType)
-        precondition(isValid, errorType)
-
+    func createEvent(withEventType eventType: String) -> ClickstreamEvent? {
+        let eventError = Event.checkEventType(eventType: eventType)
+        if eventError.errorCode > 0 {
+            recordEventError(eventError)
+            return nil
+        }
         let event = ClickstreamEvent(eventType: eventType,
                                      appId: clickstream.configuration.appId,
                                      uniqueId: clickstream.userUniqueId,
@@ -124,7 +126,22 @@ class AnalyticsClient: AnalyticsClientBehaviour {
         try eventRecorder.save(event)
     }
 
+    func recordEventError(_ eventError: Event.EventError) {
+        Task {
+            do {
+                let event = createEvent(withEventType: Event.PresetEvent.CLICKSTREAM_ERROR)!
+                event.addAttribute(eventError.errorCode, forKey: Event.ReservedAttribute.ERROR_CODE)
+                event.addAttribute(eventError.errorMessage, forKey: Event.ReservedAttribute.ERROR_MESSAGE)
+                try await record(event)
+            } catch {
+                log.error("Failed to record event with error:\(error)")
+            }
+        }
+    }
+
     func submitEvents(isBackgroundMode: Bool = false) {
         eventRecorder.submitEvents(isBackgroundMode: isBackgroundMode)
     }
 }
+
+extension AnalyticsClient: ClickstreamLogger {}

--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -45,7 +45,7 @@ class AutoRecordEventClient {
         if !clickstream.configuration.isTrackScreenViewEvents {
             return
         }
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SCREEN_VIEW)!
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SCREEN_VIEW)
         let eventTimestamp = event.timestamp
         event.addAttribute(screenName, forKey: Event.ReservedAttribute.SCREEN_NAME)
         event.addAttribute(screenPath, forKey: Event.ReservedAttribute.SCREEN_ID)
@@ -77,7 +77,7 @@ class AutoRecordEventClient {
         if lastScreenStartTimestamp == 0 { return }
         lastEngageTime = Date().millisecondsSince1970 - lastScreenStartTimestamp
         if clickstream.configuration.isTrackUserEngagementEvents, lastEngageTime > Constants.minEngagementTime {
-            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.USER_ENGAGEMENT)!
+            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.USER_ENGAGEMENT)
             event.addAttribute(lastEngageTime, forKey: Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP)
             if lastScreenName != nil, lastScreenPath != nil, lastScreenUniqueId != nil {
                 event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
@@ -113,7 +113,7 @@ class AutoRecordEventClient {
         if appVersion != nil {
             let currentAppVersion = clickstream.systemInfo.appVersion
             if appVersion != currentAppVersion {
-                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_UPDATE)!
+                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_UPDATE)
                 event.addAttribute(appVersion!, forKey: Event.ReservedAttribute.PREVIOUS_APP_VERSION)
                 recordEvent(event)
                 UserDefaultsUtil.saveAppVersion(storage: clickstream.storage, appVersion: currentAppVersion!)
@@ -128,7 +128,7 @@ class AutoRecordEventClient {
         if osVersion != nil {
             let currentOSVersion = clickstream.systemInfo.osVersion
             if osVersion != currentOSVersion {
-                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.OS_UPDATE)!
+                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.OS_UPDATE)
                 event.addAttribute(osVersion!, forKey: Event.ReservedAttribute.PREVIOUS_OS_VERSION)
                 recordEvent(event)
                 UserDefaultsUtil.saveOSVersion(storage: clickstream.storage, osVersion: currentOSVersion!)
@@ -144,12 +144,12 @@ class AutoRecordEventClient {
             checkOSVersionUpdate(clickstream: clickstream)
         }
         if isFirstOpen {
-            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.FIRST_OPEN)!
+            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.FIRST_OPEN)
             recordEvent(event)
             UserDefaultsUtil.saveIsFirstOpen(storage: clickstream.storage, isFirstOpen: "false")
             isFirstOpen = false
         }
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_START)!
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_START)
         event.addAttribute(isFirstTime, forKey: Event.ReservedAttribute.IS_FIRST_TIME)
         if lastScreenName != nil, lastScreenPath != nil {
             event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
@@ -160,7 +160,7 @@ class AutoRecordEventClient {
     }
 
     func recordAppEnd() {
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_END)!
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_END)
         if lastScreenName != nil, lastScreenPath != nil, lastScreenUniqueId != nil {
             event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
             event.addAttribute(lastScreenPath!, forKey: Event.ReservedAttribute.SCREEN_ID)
@@ -170,7 +170,7 @@ class AutoRecordEventClient {
     }
 
     func recordSessionStartEvent() {
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SESSION_START)!
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SESSION_START)
         recordEvent(event)
     }
 

--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -45,7 +45,7 @@ class AutoRecordEventClient {
         if !clickstream.configuration.isTrackScreenViewEvents {
             return
         }
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SCREEN_VIEW)
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SCREEN_VIEW)!
         let eventTimestamp = event.timestamp
         event.addAttribute(screenName, forKey: Event.ReservedAttribute.SCREEN_NAME)
         event.addAttribute(screenPath, forKey: Event.ReservedAttribute.SCREEN_ID)
@@ -77,7 +77,7 @@ class AutoRecordEventClient {
         if lastScreenStartTimestamp == 0 { return }
         lastEngageTime = Date().millisecondsSince1970 - lastScreenStartTimestamp
         if clickstream.configuration.isTrackUserEngagementEvents, lastEngageTime > Constants.minEngagementTime {
-            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.USER_ENGAGEMENT)
+            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.USER_ENGAGEMENT)!
             event.addAttribute(lastEngageTime, forKey: Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP)
             if lastScreenName != nil, lastScreenPath != nil, lastScreenUniqueId != nil {
                 event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
@@ -113,7 +113,7 @@ class AutoRecordEventClient {
         if appVersion != nil {
             let currentAppVersion = clickstream.systemInfo.appVersion
             if appVersion != currentAppVersion {
-                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_UPDATE)
+                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_UPDATE)!
                 event.addAttribute(appVersion!, forKey: Event.ReservedAttribute.PREVIOUS_APP_VERSION)
                 recordEvent(event)
                 UserDefaultsUtil.saveAppVersion(storage: clickstream.storage, appVersion: currentAppVersion!)
@@ -128,7 +128,7 @@ class AutoRecordEventClient {
         if osVersion != nil {
             let currentOSVersion = clickstream.systemInfo.osVersion
             if osVersion != currentOSVersion {
-                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.OS_UPDATE)
+                let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.OS_UPDATE)!
                 event.addAttribute(osVersion!, forKey: Event.ReservedAttribute.PREVIOUS_OS_VERSION)
                 recordEvent(event)
                 UserDefaultsUtil.saveOSVersion(storage: clickstream.storage, osVersion: currentOSVersion!)
@@ -144,12 +144,12 @@ class AutoRecordEventClient {
             checkOSVersionUpdate(clickstream: clickstream)
         }
         if isFirstOpen {
-            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.FIRST_OPEN)
+            let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.FIRST_OPEN)!
             recordEvent(event)
             UserDefaultsUtil.saveIsFirstOpen(storage: clickstream.storage, isFirstOpen: "false")
             isFirstOpen = false
         }
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_START)
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_START)!
         event.addAttribute(isFirstTime, forKey: Event.ReservedAttribute.IS_FIRST_TIME)
         if lastScreenName != nil, lastScreenPath != nil {
             event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
@@ -160,7 +160,7 @@ class AutoRecordEventClient {
     }
 
     func recordAppEnd() {
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_END)
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.APP_END)!
         if lastScreenName != nil, lastScreenPath != nil, lastScreenUniqueId != nil {
             event.addAttribute(lastScreenName!, forKey: Event.ReservedAttribute.SCREEN_NAME)
             event.addAttribute(lastScreenPath!, forKey: Event.ReservedAttribute.SCREEN_ID)
@@ -170,7 +170,7 @@ class AutoRecordEventClient {
     }
 
     func recordSessionStartEvent() {
-        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SESSION_START)
+        let event = clickstream.analyticsClient.createEvent(withEventType: Event.PresetEvent.SESSION_START)!
         recordEvent(event)
     }
 
@@ -203,7 +203,7 @@ class AutoRecordEventClient {
             do {
                 try await clickstream.analyticsClient.record(event)
             } catch {
-                log.error("Record event error:\(error)")
+                log.error("Failed to record event with error:\(error)")
             }
         }
     }

--- a/Sources/Clickstream/Dependency/Clickstream/Event/ClickstreamEvent.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/ClickstreamEvent.swift
@@ -45,8 +45,9 @@ class ClickstreamEvent: AnalyticsPropertiesModel, Hashable {
 
     func addAttribute(_ attribute: AttributeValue, forKey key: String) {
         let eventError = Event.checkAttribute(currentNumber: attributes.count, key: key, value: attribute)
-        if eventError != nil, key != Event.ReservedAttribute.EXCEPTION_STACK {
-            attributes[eventError!.errorType] = eventError!.errorMessage
+        if eventError.errorCode > 0, key != Event.ReservedAttribute.EXCEPTION_STACK {
+            attributes[Event.ReservedAttribute.ERROR_CODE] = eventError.errorCode
+            attributes[Event.ReservedAttribute.ERROR_MESSAGE] = eventError.errorMessage
         } else {
             attributes[key] = attribute
         }

--- a/Sources/Clickstream/Dependency/Clickstream/Event/Event.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/Event.swift
@@ -15,7 +15,7 @@ enum Event {
     ///   - key: attribute key
     ///   - value: attribute value
     /// - Returns: the ErrorType
-    static func checkAttribute(currentNumber: Int, key: String, value: AttributeValue) -> EventError? {
+    static func checkAttribute(currentNumber: Int, key: String, value: AttributeValue) -> EventError {
         if currentNumber >= Limit.MAX_NUM_OF_ATTRIBUTES {
             let errorMsg = """
             reached the max number of attributes limit (\(Limit.MAX_NUM_OF_ATTRIBUTES)).\
@@ -23,7 +23,7 @@ enum Event {
             """
             log.error(errorMsg)
             let errorString = "attribute name: \(key)"
-            return EventError(errorType: ErrorType.ATTRIBUTE_SIZE_EXCEED,
+            return EventError(errorCode: ErrorCode.ATTRIBUTE_SIZE_EXCEED,
                               errorMessage: "\(errorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
         }
         let nameLength = key.utf8.count
@@ -34,7 +34,7 @@ enum Event {
             """
             log.error(errorMsg)
             let errorString = "attribute name length is:(\(nameLength)) name is: \(key)"
-            return EventError(errorType: ErrorType.ATTRIBUTE_NAME_LENGTH_EXCEED,
+            return EventError(errorCode: ErrorCode.ATTRIBUTE_NAME_LENGTH_EXCEED,
                               errorMessage: "\(errorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
         }
         if !isValidName(name: key) {
@@ -44,7 +44,7 @@ enum Event {
              so the attribute will not be recorded
             """
             log.error(errorMsg)
-            return EventError(errorType: ErrorType.ATTRIBUTE_NAME_INVALID,
+            return EventError(errorCode: ErrorCode.ATTRIBUTE_NAME_INVALID,
                               errorMessage: "\(key.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
         }
         if let value = value as? String {
@@ -57,11 +57,11 @@ enum Event {
                 """
                 log.error(errorMsg)
                 let errrorString = "attribute name: \(key), attribute value: \(value)"
-                return EventError(errorType: ErrorType.ATTRIBUTE_VALUE_LENGTH_EXCEED,
+                return EventError(errorCode: ErrorCode.ATTRIBUTE_VALUE_LENGTH_EXCEED,
                                   errorMessage: "\(errrorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
             }
         }
-        return nil
+        return EventError(errorCode: ErrorCode.NO_ERROR, errorMessage: "")
     }
 
     /// Check the user attribute error.
@@ -70,7 +70,7 @@ enum Event {
     ///   - key: attribute key
     ///   - value: attribute value
     /// - Returns: the ErrorType
-    static func checkUserAttribute(currentNumber: Int, key: String, value: AttributeValue) -> EventError? {
+    static func checkUserAttribute(currentNumber: Int, key: String, value: AttributeValue) -> EventError {
         if currentNumber >= Limit.MAX_NUM_OF_USER_ATTRIBUTES {
             let errorMsg = """
             reached the max number of user attributes limit (\(Limit.MAX_NUM_OF_USER_ATTRIBUTES)).\
@@ -78,7 +78,7 @@ enum Event {
             """
             log.error(errorMsg)
             let errorString = "attribute name: \(key)"
-            return EventError(errorType: ErrorType.ATTRIBUTE_SIZE_EXCEED,
+            return EventError(errorCode: ErrorCode.USER_ATTRIBUTE_SIZE_EXCEED,
                               errorMessage: "\(errorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))...")
         }
         let nameLength = key.utf8.count
@@ -90,7 +90,7 @@ enum Event {
             """
             log.error(errorMsg)
             let errorString = "user attribute name length is:(\(nameLength)) name is: \(key)"
-            return EventError(errorType: ErrorType.ATTRIBUTE_NAME_LENGTH_EXCEED,
+            return EventError(errorCode: ErrorCode.USER_ATTRIBUTE_NAME_LENGTH_EXCEED,
                               errorMessage: "\(errorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
         }
         if !isValidName(name: key) {
@@ -100,7 +100,7 @@ enum Event {
              so the attribute will not be recorded
             """
             log.error(errorMsg)
-            return EventError(errorType: ErrorType.ATTRIBUTE_NAME_INVALID,
+            return EventError(errorCode: ErrorCode.USER_ATTRIBUTE_NAME_INVALID,
                               errorMessage: "\(key.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
         }
         if let value = value as? String {
@@ -113,31 +113,33 @@ enum Event {
                 """
                 log.error(errorMsg)
                 let errrorString = "attribute name: \(key), attribute value: \(value)"
-                return EventError(errorType: ErrorType.ATTRIBUTE_VALUE_LENGTH_EXCEED,
+                return EventError(errorCode: ErrorCode.USER_ATTRIBUTE_VALUE_LENGTH_EXCEED,
                                   errorMessage: "\(errrorString.prefix(Limit.MAX_LENGTH_OF_ERROR_VALUE))")
             }
         }
-        return nil
+        return EventError(errorCode: ErrorCode.NO_ERROR, errorMessage: "")
     }
 
     /// Check the event name whether valide
     /// - Parameter eventType: the event name
-    /// - Returns: the eventType is valide and the error type
-    static func isValidEventType(eventType: String) -> (Bool, String) {
+    /// - Returns: the EventError object
+    static func checkEventType(eventType: String) -> EventError {
         if eventType.utf8.count > Event.Limit.MAX_EVENT_TYPE_LENGTH {
             let errorMsg = """
             Event name is too long, the max event type length is \
             \(Limit.MAX_EVENT_TYPE_LENGTH) characters. event name: \(eventType)
             """
-            return (false, errorMsg)
+            log.error(errorMsg)
+            return EventError(errorCode: ErrorCode.EVENT_NAME_LENGTH_EXCEED, errorMessage: errorMsg)
         } else if !isValidName(name: eventType) {
             let errorMsg = """
             Event name can only contains uppercase and lowercase letters, underscores, number,\
              and is not start with a number. event name: \(eventType)
             """
-            return (false, errorMsg)
+            log.error(errorMsg)
+            return EventError(errorCode: ErrorCode.EVENT_NAME_INVALID, errorMessage: errorMsg)
         }
-        return (true, "")
+        return EventError(errorCode: ErrorCode.NO_ERROR, errorMessage: "")
     }
 
     /// Verify the string whether only contains number, uppercase and lowercase letters,
@@ -173,6 +175,8 @@ enum Event {
         static let EXCEPTION_NAME = "_exception_name"
         static let EXCEPTION_REASON = "_exception_reason"
         static let EXCEPTION_STACK = "_excepiton_stack"
+        static let ERROR_CODE = "_error_code"
+        static let ERROR_MESSAGE = "_error_message"
     }
 
     enum User {
@@ -217,20 +221,28 @@ enum Event {
         static let APP_START = "_app_start"
         static let APP_END = "_app_end"
         static let APP_EXCEPTION = "_app_exception"
+        static let CLICKSTREAM_ERROR = "_clickstream_error"
     }
 
-    enum ErrorType {
-        static let ATTRIBUTE_NAME_INVALID = "_error_name_invalid"
-        static let ATTRIBUTE_NAME_LENGTH_EXCEED = "_error_name_length_exceed"
-        static let ATTRIBUTE_VALUE_LENGTH_EXCEED = "_error_value_length_exceed"
-        static let ATTRIBUTE_SIZE_EXCEED = "_error_attribute_size_exceed"
+    enum ErrorCode {
+        static let NO_ERROR = 0
+        static let EVENT_NAME_INVALID = 1_001
+        static let EVENT_NAME_LENGTH_EXCEED = 1_002
+        static let ATTRIBUTE_NAME_LENGTH_EXCEED = 2_001
+        static let ATTRIBUTE_NAME_INVALID = 2_002
+        static let ATTRIBUTE_VALUE_LENGTH_EXCEED = 2_003
+        static let ATTRIBUTE_SIZE_EXCEED = 2_004
+        static let USER_ATTRIBUTE_SIZE_EXCEED = 3_001
+        static let USER_ATTRIBUTE_NAME_LENGTH_EXCEED = 3_002
+        static let USER_ATTRIBUTE_NAME_INVALID = 3_003
+        static let USER_ATTRIBUTE_VALUE_LENGTH_EXCEED = 3_004
     }
 
     class EventError {
-        let errorType: String
+        let errorCode: Int
         let errorMessage: String
-        init(errorType: String, errorMessage: String) {
-            self.errorType = errorType
+        init(errorCode: Int, errorMessage: String) {
+            self.errorCode = errorCode
             self.errorMessage = errorMessage
         }
     }

--- a/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
@@ -55,26 +55,30 @@ class AnalyticsClientTest: XCTestCase {
     func testAddGlobalAttributeForExceedNameLength() {
         let exceedName = String(repeating: "a", count: 51)
         analyticsClient.addGlobalAttribute("value", forKey: exceedName)
-        let errorValue = analyticsClient.globalAttributes["_error_name_length_exceed"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains(exceedName))
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_NAME_LENGTH_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
     }
 
     func testAddGlobalAttributeForInvalidName() {
         let invalidName = "1_goods_expose"
         analyticsClient.addGlobalAttribute("value", forKey: invalidName)
-        let errorValue = analyticsClient.globalAttributes["_error_name_invalid"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains(invalidName))
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_NAME_INVALID, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains(invalidName))
     }
 
     func testAddGlobalAttributeForExceedValueLength() {
         let exceedValue = String(repeating: "a", count: 1_025)
         analyticsClient.addGlobalAttribute(exceedValue, forKey: "name01")
-        let errorValue = analyticsClient.globalAttributes["_error_value_length_exceed"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains("name01"))
-        XCTAssertTrue(errorValue!.contains("attribute value:"))
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_VALUE_LENGTH_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains("name01"))
     }
 
     func testRemoveGlobalAttribute() {
@@ -100,17 +104,20 @@ class AnalyticsClientTest: XCTestCase {
         for i in 0 ..< 501 {
             analyticsClient.addGlobalAttribute("value", forKey: "name\(i)")
         }
-        let sizeExceedValue = analyticsClient.globalAttributes["_error_attribute_size_exceed"] as? String
-        XCTAssertNotNil(sizeExceedValue)
-        XCTAssertTrue(sizeExceedValue!.contains("name500"))
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_SIZE_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+
+        XCTAssertTrue(errorValue.contains("name500"))
     }
 
     func testAddGlobalAttributeSameNameMultiTimes() {
         for i in 0 ..< 500 {
             analyticsClient.addGlobalAttribute("value\(i)", forKey: "name")
         }
-        let sizeExceedValue = analyticsClient.globalAttributes["_error_attribute_size_exceed"]
-        XCTAssertNil(sizeExceedValue)
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(0, eventRecorder.saveCount)
         let globalAttributeCount = analyticsClient.globalAttributes.count
         XCTAssertEqual(1, globalAttributeCount)
     }
@@ -128,26 +135,34 @@ class AnalyticsClientTest: XCTestCase {
     func testAddUserAttributeForExceedNameLength() {
         let exceedName = String(repeating: "a", count: 51)
         analyticsClient.addUserAttribute("value", forKey: exceedName)
-        let errorValue = analyticsClient.globalAttributes["_error_name_length_exceed"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains(exceedName))
+
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.USER_ATTRIBUTE_NAME_LENGTH_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains(exceedName))
     }
 
     func testAddUserAttributeForInvalidName() {
         let invalidName = "1_goods_expose"
         analyticsClient.addUserAttribute("value", forKey: invalidName)
-        let errorValue = analyticsClient.globalAttributes["_error_name_invalid"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains(invalidName))
+
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.USER_ATTRIBUTE_NAME_INVALID, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains(invalidName))
     }
 
     func testAddUserAttributeForExceedValueLength() {
         let exceedValue = String(repeating: "a", count: 257)
         analyticsClient.addUserAttribute(exceedValue, forKey: "name01")
-        let errorValue = analyticsClient.globalAttributes["_error_value_length_exceed"] as? String
-        XCTAssertNotNil(errorValue)
-        XCTAssertTrue(errorValue!.contains("name01"))
-        XCTAssertTrue(errorValue!.contains("attribute value:"))
+
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.USER_ATTRIBUTE_VALUE_LENGTH_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains("name01"))
     }
 
     func testRemoveUserAttribute() {
@@ -173,17 +188,19 @@ class AnalyticsClientTest: XCTestCase {
         for i in 0 ..< 101 {
             analyticsClient.addUserAttribute("value", forKey: "name\(i)")
         }
-        let sizeExceedValue = analyticsClient.globalAttributes["_error_attribute_size_exceed"] as? String
-        XCTAssertNotNil(sizeExceedValue)
-        XCTAssertTrue(sizeExceedValue!.contains("name100"))
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.USER_ATTRIBUTE_SIZE_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+        let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertTrue(errorValue.contains("attribute name"))
     }
 
     func testAddUserAttributeSameNameMultiTimes() {
         for i in 0 ..< 100 {
             analyticsClient.addUserAttribute("value\(i)", forKey: "name")
         }
-        let sizeExceedValue = analyticsClient.globalAttributes["_error_attribute_size_exceed"]
-        XCTAssertNil(sizeExceedValue)
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertEqual(0, eventRecorder.saveCount)
         let userAttributeCount = analyticsClient.userAttributes.count
         XCTAssertEqual(2, userAttributeCount)
     }
@@ -237,12 +254,12 @@ class AnalyticsClientTest: XCTestCase {
 
     func testCreateEvent() {
         let eventType = "testEvent"
-        let event = analyticsClient.createEvent(withEventType: eventType)
+        let event = analyticsClient.createEvent(withEventType: eventType)!
         XCTAssertEqual(event.eventType, eventType)
     }
 
     func testRecordRecordEventWithGlobalAttribute() async {
-        let event = analyticsClient.createEvent(withEventType: "testEvent")
+        let event = analyticsClient.createEvent(withEventType: "testEvent")!
         XCTAssertTrue(event.attributes.isEmpty)
 
         analyticsClient.addGlobalAttribute("test_0", forKey: "attribute_0")
@@ -268,7 +285,7 @@ class AnalyticsClientTest: XCTestCase {
     }
 
     func testRecordRecordEventWithUserAttribute() async {
-        let event = analyticsClient.createEvent(withEventType: "testEvent")
+        let event = analyticsClient.createEvent(withEventType: "testEvent")!
         XCTAssertTrue(event.attributes.isEmpty)
 
         analyticsClient.addUserAttribute("test_0", forKey: "attribute_0")

--- a/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
@@ -104,7 +104,7 @@ class AnalyticsClientTest: XCTestCase {
         for i in 0 ..< 501 {
             analyticsClient.addGlobalAttribute("value", forKey: "name\(i)")
         }
-        Thread.sleep(forTimeInterval: 0.05)
+        Thread.sleep(forTimeInterval: 0.1)
         XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
         XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_SIZE_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
         let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String

--- a/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
@@ -254,12 +254,12 @@ class AnalyticsClientTest: XCTestCase {
 
     func testCreateEvent() {
         let eventType = "testEvent"
-        let event = analyticsClient.createEvent(withEventType: eventType)!
+        let event = analyticsClient.createEvent(withEventType: eventType)
         XCTAssertEqual(event.eventType, eventType)
     }
 
     func testRecordRecordEventWithGlobalAttribute() async {
-        let event = analyticsClient.createEvent(withEventType: "testEvent")!
+        let event = analyticsClient.createEvent(withEventType: "testEvent")
         XCTAssertTrue(event.attributes.isEmpty)
 
         analyticsClient.addGlobalAttribute("test_0", forKey: "attribute_0")
@@ -285,7 +285,7 @@ class AnalyticsClientTest: XCTestCase {
     }
 
     func testRecordRecordEventWithUserAttribute() async {
-        let event = analyticsClient.createEvent(withEventType: "testEvent")!
+        let event = analyticsClient.createEvent(withEventType: "testEvent")
         XCTAssertTrue(event.attributes.isEmpty)
 
         analyticsClient.addUserAttribute("test_0", forKey: "attribute_0")
@@ -313,5 +313,22 @@ class AnalyticsClientTest: XCTestCase {
     func testSubmit() {
         analyticsClient.submitEvents()
         XCTAssertEqual(eventRecorder.submitCount, 1)
+    }
+
+    func testCheckEventNameWithNameInvalidError() {
+        let isValidEvent = analyticsClient.checkEventName("01Event")
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertFalse(isValidEvent)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.EVENT_NAME_INVALID, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
+    }
+
+    func testCheckEventNameWithNameLengthExceedError() {
+        let exceedName = String(repeating: "a", count: 51)
+        let isValidEvent = analyticsClient.checkEventName(exceedName)
+        Thread.sleep(forTimeInterval: 0.02)
+        XCTAssertFalse(isValidEvent)
+        XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
+        XCTAssertEqual(Event.ErrorCode.EVENT_NAME_LENGTH_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
     }
 }

--- a/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/AnalyticsClientTest.swift
@@ -104,7 +104,7 @@ class AnalyticsClientTest: XCTestCase {
         for i in 0 ..< 501 {
             analyticsClient.addGlobalAttribute("value", forKey: "name\(i)")
         }
-        Thread.sleep(forTimeInterval: 0.02)
+        Thread.sleep(forTimeInterval: 0.05)
         XCTAssertEqual(Event.PresetEvent.CLICKSTREAM_ERROR, eventRecorder.lastSavedEvent?.eventType)
         XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_SIZE_EXCEED, eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int)
         let errorValue = eventRecorder.lastSavedEvent?.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String

--- a/Tests/ClickstreamTests/Clickstream/ClickstreamEventTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/ClickstreamEventTest.swift
@@ -37,27 +37,30 @@ class ClickstreamEventTest: XCTestCase {
     func testAddAttributeErrorForInvalidKey() {
         clickstreamEvent.addAttribute(133_232_123, forKey: "1GoodsId")
         XCTAssertNil(clickstreamEvent.attribute(forKey: "isNewGoods"))
-        let erroValueString = clickstreamEvent.attribute(forKey: Event.ErrorType.ATTRIBUTE_NAME_INVALID) as! String
-        XCTAssertNotNil(erroValueString)
-        XCTAssertTrue(erroValueString.contains("1GoodsId"))
+        let errorCode = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int
+        let errorValueString = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_NAME_INVALID, errorCode)
+        XCTAssertTrue(errorValueString.contains("1GoodsId"))
     }
 
     func testAddAttributeErrorForExceedMaxLenthOfKey() {
         let longAttributeKey = String(repeating: "a", count: 51)
         clickstreamEvent.addAttribute("testValue", forKey: longAttributeKey)
         XCTAssertNil(clickstreamEvent.attribute(forKey: "longAttributeKey"))
-        let erroValueString = clickstreamEvent.attribute(forKey: Event.ErrorType.ATTRIBUTE_NAME_LENGTH_EXCEED) as! String
-        XCTAssertNotNil(erroValueString)
-        XCTAssertTrue(erroValueString.contains(longAttributeKey))
+        let errorCode = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int
+        let errorValueString = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_NAME_LENGTH_EXCEED, errorCode)
+        XCTAssertTrue(errorValueString.contains(longAttributeKey))
     }
 
     func testAddAttributeErrorForExceedMaxLenthOfValue() {
         let longAttributeValue = String(repeating: "a", count: 1_025)
         clickstreamEvent.addAttribute(longAttributeValue, forKey: "testKey")
         XCTAssertNil(clickstreamEvent.attribute(forKey: "testKey"))
-        let erroValueString = clickstreamEvent.attribute(forKey: Event.ErrorType.ATTRIBUTE_VALUE_LENGTH_EXCEED) as! String
-        XCTAssertNotNil(erroValueString)
-        XCTAssertTrue(erroValueString.contains("testKey"))
+        let errorCode = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) as! Int
+        let errorValueString = clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_MESSAGE) as! String
+        XCTAssertEqual(Event.ErrorCode.ATTRIBUTE_VALUE_LENGTH_EXCEED, errorCode)
+        XCTAssertTrue(errorValueString.contains("testKey"))
     }
 
     func testEventEqualsFail() {

--- a/Tests/ClickstreamTests/ClickstreamPluginBehaviorTest.swift
+++ b/Tests/ClickstreamTests/ClickstreamPluginBehaviorTest.swift
@@ -77,6 +77,12 @@ class ClickstreamPluginBehaviorTest: ClickstreamPluginTestBase {
         XCTAssertEqual(1, updateCount)
     }
 
+    func testCheckEventName() {
+        let result = analyticsClient.checkEventName("testEvent")
+        XCTAssertTrue(result)
+        XCTAssertEqual(1, analyticsClient.checkEventNameCount)
+    }
+
     func testRecordEvent() {
         let expectation = expectation(description: "record event")
         analyticsClient.setRecordExpectation(expectation)

--- a/Tests/ClickstreamTests/EventTest.swift
+++ b/Tests/ClickstreamTests/EventTest.swift
@@ -10,17 +10,18 @@ import XCTest
 
 class EventTest: XCTestCase {
     func testIsValidEventType() {
-        XCTAssertFalse(Event.isValidEventType(eventType: "").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "abc").0)
-        XCTAssertFalse(Event.isValidEventType(eventType: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1").0)
-        XCTAssertFalse(Event.isValidEventType(eventType: "123").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "AAA").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "a_ab").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "a_ab_1A").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "add_to_cart").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "Screen_view").0)
-        XCTAssertFalse(Event.isValidEventType(eventType: "0abc").0)
-        XCTAssertFalse(Event.isValidEventType(eventType: "9Abc").0)
-        XCTAssertTrue(Event.isValidEventType(eventType: "A9bc").0)
+        let noError = Event.ErrorCode.NO_ERROR
+        XCTAssertFalse(Event.checkEventType(eventType: "").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "abc").errorCode == noError)
+        XCTAssertFalse(Event.checkEventType(eventType: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1").errorCode == noError)
+        XCTAssertFalse(Event.checkEventType(eventType: "123").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "AAA").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "a_ab").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "a_ab_1A").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "add_to_cart").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "Screen_view").errorCode == noError)
+        XCTAssertFalse(Event.checkEventType(eventType: "0abc").errorCode == noError)
+        XCTAssertFalse(Event.checkEventType(eventType: "9Abc").errorCode == noError)
+        XCTAssertTrue(Event.checkEventType(eventType: "A9bc").errorCode == noError)
     }
 }

--- a/Tests/ClickstreamTests/Mock/MockAnalyticsClient.swift
+++ b/Tests/ClickstreamTests/Mock/MockAnalyticsClient.swift
@@ -100,7 +100,7 @@ class MockAnalyticsClient: AnalyticsClientBehaviour {
         createEventCount += 1
     }
 
-    func createEvent(withEventType eventType: String) -> ClickstreamEvent {
+    func createEvent(withEventType eventType: String) -> ClickstreamEvent? {
         increaseCreateEventCount()
         let storage = ClickstreamContextStorage(userDefaults: UserDefaults.standard)
         return ClickstreamEvent(eventType: eventType, appId: "", uniqueId: "", session: Session(uniqueId: "", sessionIndex: 1),

--- a/Tests/ClickstreamTests/Mock/MockAnalyticsClient.swift
+++ b/Tests/ClickstreamTests/Mock/MockAnalyticsClient.swift
@@ -93,6 +93,14 @@ class MockAnalyticsClient: AnalyticsClientBehaviour {
         updateUserAttributesExpectation?.fulfill()
     }
 
+    // MARK: - CheckEventName
+
+    var checkEventNameCount = 0
+    func checkEventName(_ eventName: String) -> Bool {
+        checkEventNameCount += 1
+        return true
+    }
+
     // MARK: - CreateEvent
 
     var createEventCount = 0
@@ -100,7 +108,7 @@ class MockAnalyticsClient: AnalyticsClientBehaviour {
         createEventCount += 1
     }
 
-    func createEvent(withEventType eventType: String) -> ClickstreamEvent? {
+    func createEvent(withEventType eventType: String) -> ClickstreamEvent {
         increaseCreateEventCount()
         let storage = ClickstreamContextStorage(userDefaults: UserDefaults.standard)
         return ClickstreamEvent(eventType: eventType, appId: "", uniqueId: "", session: Session(uniqueId: "", sessionIndex: 1),


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
1. add error codes consistent with Web SDK
2. add _clickstream_error preset event, when event name, global/user attribute is invalid.

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
