### PR TITLE
fix: optimize engagement time and previous timestamp attribute in first screen view

### DIFF
--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -36,7 +36,9 @@ class AutoRecordEventClient {
 
     func onViewDidAppear(screenName: String, screenPath: String, screenHashValue: String) {
         if !isSameScreen(screenName, screenPath, screenHashValue) {
-            recordUserEngagement()
+            if lastScreenName != nil {
+                recordUserEngagement()
+            }
             recordScreenView(screenName, screenPath, screenHashValue)
         }
     }
@@ -86,11 +88,7 @@ class AutoRecordEventClient {
     }
 
     func getPreviousScreenViewTimestamp() -> Int64 {
-        if lastScreenStartTimestamp > 0 {
-            return lastScreenStartTimestamp
-        } else {
-            return UserDefaultsUtil.getPreviousScreenViewTimestamp(storage: clickstream.storage)
-        }
+        UserDefaultsUtil.getPreviousScreenViewTimestamp(storage: clickstream.storage)
     }
 
     func isSameScreen(_ screenName: String, _ screenPath: String, _ screenUniqueId: String) -> Bool {


### PR DESCRIPTION
## Description
1. remove `_engagement_time_msec` in first screen view event
2. optimize getting the `_previous_timestamp` value in first screen view event

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
