### PR TITLE
fix: the total number of item attributes is limited to 10

### DIFF
--- a/Sources/Clickstream/Dependency/Clickstream/Event/EventChecker.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/EventChecker.swift
@@ -166,9 +166,7 @@ class EventChecker {
     static func checkItem(currentNumber: Int, item: ClickstreamAttribute) ->
         (eventError: EventError, resultItem: ClickstreamAttribute)
     {
-        if itemKeySet.isEmpty {
-            initItemKeySet()
-        }
+        initItemKeySet()
         var resultItem: ClickstreamAttribute = [:]
         if currentNumber >= Event.Limit.MAX_NUM_OF_ITEMS {
             let itemJsonString = (item as JsonObject).toJsonString()
@@ -256,22 +254,24 @@ class EventChecker {
     }
 
     static func initItemKeySet() {
-        itemKeySet = Set<String>([
-            ClickstreamAnalytics.Item.ITEM_ID,
-            ClickstreamAnalytics.Item.ITEM_NAME,
-            ClickstreamAnalytics.Item.LOCATION_ID,
-            ClickstreamAnalytics.Item.ITEM_BRAND,
-            ClickstreamAnalytics.Item.CURRENCY,
-            ClickstreamAnalytics.Item.PRICE,
-            ClickstreamAnalytics.Item.QUANTITY,
-            ClickstreamAnalytics.Item.CREATIVE_NAME,
-            ClickstreamAnalytics.Item.CREATIVE_SLOT,
-            ClickstreamAnalytics.Item.ITEM_CATEGORY,
-            ClickstreamAnalytics.Item.ITEM_CATEGORY2,
-            ClickstreamAnalytics.Item.ITEM_CATEGORY3,
-            ClickstreamAnalytics.Item.ITEM_CATEGORY4,
-            ClickstreamAnalytics.Item.ITEM_CATEGORY5
-        ])
+        if itemKeySet.isEmpty {
+            itemKeySet = Set<String>([
+                ClickstreamAnalytics.Item.ITEM_ID,
+                ClickstreamAnalytics.Item.ITEM_NAME,
+                ClickstreamAnalytics.Item.LOCATION_ID,
+                ClickstreamAnalytics.Item.ITEM_BRAND,
+                ClickstreamAnalytics.Item.CURRENCY,
+                ClickstreamAnalytics.Item.PRICE,
+                ClickstreamAnalytics.Item.QUANTITY,
+                ClickstreamAnalytics.Item.CREATIVE_NAME,
+                ClickstreamAnalytics.Item.CREATIVE_SLOT,
+                ClickstreamAnalytics.Item.ITEM_CATEGORY,
+                ClickstreamAnalytics.Item.ITEM_CATEGORY2,
+                ClickstreamAnalytics.Item.ITEM_CATEGORY3,
+                ClickstreamAnalytics.Item.ITEM_CATEGORY4,
+                ClickstreamAnalytics.Item.ITEM_CATEGORY5
+            ])
+        }
     }
 }
 

--- a/Sources/Clickstream/Dependency/Clickstream/Event/EventChecker.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/EventChecker.swift
@@ -166,6 +166,9 @@ class EventChecker {
     static func checkItem(currentNumber: Int, item: ClickstreamAttribute) ->
         (eventError: EventError, resultItem: ClickstreamAttribute)
     {
+        if itemKeySet.isEmpty {
+            initItemKeySet()
+        }
         var resultItem: ClickstreamAttribute = [:]
         if currentNumber >= Event.Limit.MAX_NUM_OF_ITEMS {
             let itemJsonString = (item as JsonObject).toJsonString()

--- a/Tests/ClickstreamTests/Clickstream/ClickstreamEventTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/ClickstreamEventTest.swift
@@ -113,6 +113,22 @@ class ClickstreamEventTest: XCTestCase {
         XCTAssertEqual(0, clickstreamEvent.items.count)
     }
 
+    func testAddItemPrestAndCustomAttributeNotExceedTheLimit() {
+        var item: ClickstreamAttribute = [
+            ClickstreamAnalytics.Item.ITEM_ID: 123,
+            ClickstreamAnalytics.Item.ITEM_NAME: "testName1",
+            ClickstreamAnalytics.Item.ITEM_BRAND: "Google",
+            ClickstreamAnalytics.Item.CURRENCY: "CNY",
+            ClickstreamAnalytics.Item.LOCATION_ID: "1"
+        ]
+        for i in 0 ..< 10 {
+            item["custom_attr_\(i)"] = "value_\(i)"
+        }
+        clickstreamEvent.addItem(item)
+        XCTAssertTrue(clickstreamEvent.attribute(forKey: Event.ReservedAttribute.ERROR_CODE) == nil)
+        XCTAssertEqual(1, clickstreamEvent.items.count)
+    }
+
     func testAddItemErrorForExceedMaxLengthOfAttributeName() {
         let longAttributeKey = String(repeating: "a", count: 51)
         let item: ClickstreamAttribute = [


### PR DESCRIPTION
## Description
1. fixed the issue that the total number of item attributes is limited to 10

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
