### PR TITLE
fix: add items key for objc

### DIFF
--- a/Sources/Clickstream/ClickstreamObjc.swift
+++ b/Sources/Clickstream/ClickstreamObjc.swift
@@ -107,3 +107,36 @@ import Foundation
         return result
     }
 }
+
+/// ClickstreamAnalytics preset item keys for objective-c
+/// In addition to the item attributes defined below, you can add up to 10 custom attributes to an item.
+@objcMembers public class ClickstreamItemKey: NSObject {
+    /// The id of the item
+    public static let ITEM_ID = "id"
+    /// The name of the item
+    public static let ITEM_NAME = "name"
+    /// The location id of the item
+    public static let LOCATION_ID = "location_id"
+    /// The brand of the item
+    public static let ITEM_BRAND = "brand"
+    /// The currency of the item
+    public static let CURRENCY = "currency"
+    /// The price of the item
+    public static let PRICE = "price"
+    /// The quantity of the item
+    public static let QUANTITY = "quantity"
+    /// The creative name of the item
+    public static let CREATIVE_NAME = "creative_name"
+    /// The creative slot of the item
+    public static let CREATIVE_SLOT = "creative_slot"
+    /// The category of the item
+    public static let ITEM_CATEGORY = "item_category"
+    /// The category2 of the item
+    public static let ITEM_CATEGORY2 = "item_category2"
+    /// The category3 of the item
+    public static let ITEM_CATEGORY3 = "item_category3"
+    /// The category4 of the item
+    public static let ITEM_CATEGORY4 = "item_category4"
+    /// The category5 of the item
+    public static let ITEM_CATEGORY5 = "item_category5"
+}

--- a/Tests/ClickstreamTests/IntegrationTest.swift
+++ b/Tests/ClickstreamTests/IntegrationTest.swift
@@ -308,10 +308,11 @@ class IntegrationTest: XCTestCase {
 
     func testRecordEventWithItemForObjc() throws {
         let item: NSDictionary = [
-            "id": 123,
-            "name": "Nature",
-            "category": "book",
-            "price": 99.9
+            ClickstreamItemKey.ITEM_ID: 123,
+            ClickstreamItemKey.ITEM_NAME: "Nature",
+            ClickstreamItemKey.ITEM_CATEGORY: "book",
+            ClickstreamItemKey.PRICE: 99.9,
+            "event_category": "recommended"
         ]
         ClickstreamObjc.recordEvent("testEvent",
                                     ["id": 123],
@@ -323,7 +324,8 @@ class IntegrationTest: XCTestCase {
         let eventItem = items[0]
         XCTAssertEqual(123, eventItem["id"] as! Int)
         XCTAssertEqual("Nature", eventItem["name"] as! String)
-        XCTAssertEqual("book", eventItem["category"] as! String)
+        XCTAssertEqual("book", eventItem["item_category"] as! String)
+        XCTAssertEqual("recommended", eventItem["event_category"] as! String)
         XCTAssertEqual(99.9, eventItem["price"] as! Double)
     }
 


### PR DESCRIPTION
## Description
1. add ClickstreamItemKey for Objective-C API

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
