### PR TITLE
fix: first screen view name not exists in rare cases

### DIFF
--- a/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/AutoRecord/AutoRecordEventClient.swift
@@ -64,12 +64,11 @@ class AutoRecordEventClient {
         if lastEngageTime > 0 {
             event.addAttribute(lastEngageTime, forKey: Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP)
         }
-        recordEvent(event)
-
-        isEntrances = false
         lastScreenName = screenName
         lastScreenPath = screenPath
         lastScreenUniqueId = screenUniqueId
+        recordEvent(event)
+        isEntrances = false
         lastScreenStartTimestamp = eventTimestamp
         UserDefaultsUtil.savePreviousScreenViewTimestamp(storage: clickstream.storage, timestamp: eventTimestamp)
     }


### PR DESCRIPTION
## Description
1. fix first screen view name not exists in rare cases

This issue discovered by [e2e integration test](https://github.com/awslabs/clickstream-swift/actions/runs/7758708766/job/21161994170), and the integration test case will also cover this rare cases.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
