### PR TITLE
fix: crash when user attribute is empty

### DIFF
--- a/IntegrationTest/devicefarm/logcat_test.py
+++ b/IntegrationTest/devicefarm/logcat_test.py
@@ -196,7 +196,7 @@ class TestLogcatIOS:
 def get_submitted_events(path):
     submitted_events = []
     with open(path, 'r') as file:
-        pattern = re.compile(r' Send (\d+) events')
+        pattern = re.compile(r'^Send (\d+) events')
         for line in file:
             match = pattern.search(line)
             if match:
@@ -209,7 +209,7 @@ def get_recorded_events(path):
         log_lines = file.readlines()
     events = []
     first_event_pattern = re.compile(r'app_event_log:Saved event (\w+):(.*)$')
-    event_pattern = re.compile(r' Saved event (\w+):(.*)$')
+    event_pattern = re.compile(r'^Saved event (\w+):(.*)$')
 
     current_event_name = ''
 

--- a/Sources/Clickstream/Dependency/Clickstream/Event/ClickstreamEvent.swift
+++ b/Sources/Clickstream/Dependency/Clickstream/Event/ClickstreamEvent.swift
@@ -109,7 +109,9 @@ class ClickstreamEvent: AnalyticsPropertiesModel {
         if !items.isEmpty {
             event["items"] = items
         }
-        event["user"] = userAttributes
+        if !userAttributes.isEmpty {
+            event["user"] = userAttributes
+        }
         event["attributes"] = getAttributeObject(from: attributes)
         return event
     }

--- a/Tests/ClickstreamTests/Clickstream/EventRecorderTest.swift
+++ b/Tests/ClickstreamTests/Clickstream/EventRecorderTest.swift
@@ -132,7 +132,7 @@ class EventRecorderTest: XCTestCase {
         XCTAssertNotNil(event["app_version"])
         XCTAssertNotNil(event["app_package_name"])
         XCTAssertNotNil(event["app_title"])
-        XCTAssertNotNil(event["user"])
+        XCTAssertNil(event["user"])
         XCTAssertNotNil(event["attributes"])
         XCTAssertNil(event["noneExistAttribute"])
     }

--- a/Tests/ClickstreamTests/IntegrationTest.swift
+++ b/Tests/ClickstreamTests/IntegrationTest.swift
@@ -256,6 +256,7 @@ class IntegrationTest: XCTestCase {
         XCTAssertEqual((user["score"] as! JsonObject)["value"] as! Double, 85.2)
         XCTAssertEqual((user["_user_name"] as! JsonObject)["value"] as! String, "carl")
         XCTAssertNotNil(user[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP])
+        XCTAssertNotNil((user[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP] as! JsonObject)["value"])
     }
 
     func testProfileSetTimestamp() throws {


### PR DESCRIPTION
## Description
1. fix crash when user attribute is empty

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds using Swift Package Manager
- [x] All unit tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
